### PR TITLE
Fix: Add element array to children type

### DIFF
--- a/src/Components/Layout/Layout.tsx
+++ b/src/Components/Layout/Layout.tsx
@@ -3,7 +3,7 @@ import Navbar from 'Components/Navbar';
 import { Container, Contents } from './LayoutStyle';
 
 interface LayoutProps {
-  children: JSX.Element;
+  children: JSX.Element | JSX.Element[];
 }
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {


### PR DESCRIPTION
Layout 컴포넌트의 children prop의 타입에 JSX.Element[] 추가